### PR TITLE
The sinvoke syntax on a parametric function is unneccesary and delete…

### DIFF
--- a/Tutorials/Lesson1/Parametric.spec
+++ b/Tutorials/Lesson1/Parametric.spec
@@ -24,7 +24,7 @@ rule validityOfTotalFunds(method f) {
 	
 	// execute some method
    	calldataarg arg; // any argument
-	sinvoke f(e, arg); // simulate only non reverting paths 
+	f(e, arg);
 	
 	assert ( getTotalFunds(e) >= getFunds(e, e.msg.sender), "Total funds are less than user funds" );
 }

--- a/Tutorials/Lesson1/README.md
+++ b/Tutorials/Lesson1/README.md
@@ -139,7 +139,7 @@ you can define a method variable, `method f`, as a parameter to the rule or a lo
 The most common usage is to simulate any function on any arguments, as we show next.
 ```
 calldataarg arg; // any argument
-sinvoke f(e, arg); //simulate only non reverting paths
+f(e, arg);
 ```
 Different functions in the contract might have a different number or types of parameters. Using a `calldataarg` variable solves this problem and ensures each simulated function gets valid input parameters.
 


### PR DESCRIPTION
…d from .spec file as well as README. DO NOT MERGE until the production version is updated, was tested only on master. James: please update the slides as well to reflect this change. The audience asked about the meaning of the sinvoke syntax during the first lecture