### PR TITLE
Fix Simple counter example

### DIFF
--- a/Examples/Simple/CounterBroken.sol
+++ b/Examples/Simple/CounterBroken.sol
@@ -1,3 +1,5 @@
+pragma solidity < 0.8;
+
 contract Counter {
 	address public admin;
 	uint public counter;

--- a/Examples/Simple/CounterFixed.sol
+++ b/Examples/Simple/CounterFixed.sol
@@ -1,3 +1,5 @@
+pragma solidity < 0.8;
+
 library SafeMath {
 	function safeAdd(uint256 a, uint256 b) internal pure returns (uint256) {
         uint256 c = a + b;


### PR DESCRIPTION
Since solidity [0.8](https://docs.soliditylang.org/en/v0.8.12/080-breaking-changes.html), arithmetic operation revert on overflow and underflow. So the [CounterBroken](https://github.com/Certora/CertoraProverSupplementary/blob/master/Examples/Simple/CounterBroken.sol) contract complies with the [Counter specification](https://github.com/Certora/CertoraProverSupplementary/blob/master/Examples/Simple/Counter.spec) if compiled with `solc` 0.8 (issue #6). I added a pragma version to force people to use 0.7.